### PR TITLE
消除MapperScan 重复扫描警告⚠️

### DIFF
--- a/server/src/main/java/com/gregperlinli/certvault/CertVaultApplication.java
+++ b/server/src/main/java/com/gregperlinli/certvault/CertVaultApplication.java
@@ -16,7 +16,6 @@ import java.util.Map;
  * @className {@code CertVaultApplication}
  * @date 2025/3/3 15:50
  */
-@MapperScan("com.gregperlinli.certvault.mapper")
 @SpringBootApplication
 public class CertVaultApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
消除重复MapperScan重复扫描
com.gregperlinli.certvault.config.MyBatisConfig上面 已经有注解了
消除下面WARN⚠️
---
2025-05-04T22:28:57.934+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'caBindingMapper' and 'com.gregperlinli.certvault.mapper.CaBindingMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.934+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'caMapper' and 'com.gregperlinli.certvault.mapper.CaMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.934+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'certificateMapper' and 'com.gregperlinli.certvault.mapper.CertificateMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.934+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'loginRecordMapper' and 'com.gregperlinli.certvault.mapper.LoginRecordMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.934+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'roleBindingMapper' and 'com.gregperlinli.certvault.mapper.RoleBindingMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.935+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'roleMapper' and 'com.gregperlinli.certvault.mapper.RoleMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.935+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : Skipping MapperFactoryBean with name 'userMapper' and 'com.gregperlinli.certvault.mapper.UserMapper' mapperInterface. Bean already defined with the same name!
2025-05-04T22:28:57.935+08:00  WARN 23999 --- [CertVault] [  restartedMain] o.m.s.mapper.ClassPathMapperScanner      : No MyBatis mapper was found in '[com.gregperlinli.certvault.mapper]' package. Please check your configuration.

